### PR TITLE
Hotfix#27 : quiz Page, answer Page에서 뒤로 가기 버튼 작동 방지

### DIFF
--- a/lib/features/answer/answerpage.dart
+++ b/lib/features/answer/answerpage.dart
@@ -17,100 +17,104 @@ class _AnswerPageState extends State<AnswerPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: Container(
-        color: AppColors.mainLightGray,
-        child: Stack(
-          children: [
-            Positioned(
-              top: 50,
-              left: 20,
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                },
-                child: const Icon(
-                  Icons.arrow_back_ios,
-                  color: AppColors.mainDeepOrange,
+      body: PopScope(
+        canPop: false,
+        child: Container(
+          color: AppColors.mainLightGray,
+          child: Stack(
+            children: [
+              Positioned(
+                top: 50,
+                left: 20,
+                child: GestureDetector(
+                  onTap: () {
+                    Navigator.of(context)
+                        .popUntil(ModalRoute.withName('/home'));
+                  },
+                  child: const Icon(
+                    Icons.arrow_back_ios,
+                    color: AppColors.mainDeepOrange,
+                  ),
                 ),
               ),
-            ),
-            Positioned(
-              bottom: 30,
-              left: 20,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const DefaultTextStyle(
-                    style: TextStyle(
-                      fontSize: 20,
-                      color: Colors.black,
-                      height: 4,
-                    ),
-                    child: Text(
-                      '지금까지 푼 문제',
-                    ),
-                  ),
-                  const SizedBox(
-                    width: 8,
-                  ),
-                  DefaultTextStyle(
-                    style: const TextStyle(
-                      fontSize: 50,
-                      color: AppColors.mainDeepOrange,
-                      fontWeight: FontWeight.bold,
-                    ),
-                    child: Text(
-                      _solvedAnswerCnt.toString(),
-                    ),
-                  ),
-                  const DefaultTextStyle(
-                    style: TextStyle(
-                      fontSize: 20,
-                      color: Colors.black,
-                      height: 4,
-                    ),
-                    child: Text(
-                      '문',
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Positioned(
-              bottom: 150,
-              right: 0,
-              left: 0,
-              child: Center(
-                child: SizedBox(
-                  width: 330,
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.mainDeepOrange,
-                    ),
-                    onPressed: () {
-                      Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => const QuizPage()));
-                    },
-                    child: const Text(
-                      '다음 문제',
+              Positioned(
+                bottom: 30,
+                left: 20,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    const DefaultTextStyle(
                       style: TextStyle(
-                        fontSize: 40,
-                        color: Colors.white,
+                        fontSize: 20,
+                        color: Colors.black,
+                        height: 4,
+                      ),
+                      child: Text(
+                        '지금까지 푼 문제',
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 8,
+                    ),
+                    DefaultTextStyle(
+                      style: const TextStyle(
+                        fontSize: 50,
+                        color: AppColors.mainDeepOrange,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      child: Text(
+                        _solvedAnswerCnt.toString(),
+                      ),
+                    ),
+                    const DefaultTextStyle(
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: Colors.black,
+                        height: 4,
+                      ),
+                      child: Text(
+                        '문',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Positioned(
+                bottom: 150,
+                right: 0,
+                left: 0,
+                child: Center(
+                  child: SizedBox(
+                    width: 330,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.mainDeepOrange,
+                      ),
+                      onPressed: () {
+                        Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => const QuizPage()));
+                      },
+                      child: const Text(
+                        '다음 문제',
+                        style: TextStyle(
+                          fontSize: 40,
+                          color: Colors.white,
+                        ),
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
-            const Center(
-              child: AnswerpageCardwidget(
-                quizCategory: '소프트웨어공학',
-                quizExplanation: '운영체제가 제공하는 기능에 해당하지 않는 것은 무엇인가요!',
-              ),
-            )
-          ],
+              const Center(
+                child: AnswerpageCardwidget(
+                  quizCategory: '소프트웨어공학',
+                  quizExplanation: '운영체제가 제공하는 기능에 해당하지 않는 것은 무엇인가요!',
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/quiz/quizepage.dart
+++ b/lib/features/quiz/quizepage.dart
@@ -17,82 +17,86 @@ class _QuizPageState extends State<QuizPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: Container(
-        color: AppColors.mainLightGray,
-        child: Stack(
-          children: [
-            Positioned(
-              top: 50,
-              left: 20,
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.of(context).popUntil(ModalRoute.withName('/home'));
-                },
-                child: const Icon(
-                  Icons.arrow_back_ios,
-                  color: AppColors.mainDeepOrange,
+      body: PopScope(
+        canPop: false,
+        child: Container(
+          color: AppColors.mainLightGray,
+          child: Stack(
+            children: [
+              Positioned(
+                top: 50,
+                left: 20,
+                child: GestureDetector(
+                  onTap: () {
+                    Navigator.of(context)
+                        .popUntil(ModalRoute.withName('/home'));
+                  },
+                  child: const Icon(
+                    Icons.arrow_back_ios,
+                    color: AppColors.mainDeepOrange,
+                  ),
                 ),
               ),
-            ),
-            Positioned(
-              bottom: 30,
-              left: 20,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const DefaultTextStyle(
-                    style: TextStyle(
-                      fontSize: 20,
-                      color: Colors.black,
-                      height: 4,
+              Positioned(
+                bottom: 30,
+                left: 20,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    const DefaultTextStyle(
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: Colors.black,
+                        height: 4,
+                      ),
+                      child: Text(
+                        '지금까지 푼 문제',
+                      ),
                     ),
-                    child: Text(
-                      '지금까지 푼 문제',
+                    const SizedBox(
+                      width: 8,
                     ),
-                  ),
-                  const SizedBox(
-                    width: 8,
-                  ),
-                  DefaultTextStyle(
-                    style: const TextStyle(
-                      fontSize: 50,
-                      color: AppColors.mainDeepOrange,
-                      fontWeight: FontWeight.bold,
+                    DefaultTextStyle(
+                      style: const TextStyle(
+                        fontSize: 50,
+                        color: AppColors.mainDeepOrange,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      child: Text(
+                        _solvedAnswerCnt.toString(),
+                      ),
                     ),
-                    child: Text(
-                      _solvedAnswerCnt.toString(),
+                    const DefaultTextStyle(
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: Colors.black,
+                        height: 4,
+                      ),
+                      child: Text(
+                        '문',
+                      ),
                     ),
-                  ),
-                  const DefaultTextStyle(
-                    style: TextStyle(
-                      fontSize: 20,
-                      color: Colors.black,
-                      height: 4,
-                    ),
-                    child: Text(
-                      '문',
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            const Center(
-              child: QuizpageAnswerlist(
-                answerList: [
-                  '메모리 관리',
-                  'TLB(Translation)',
-                  '애플리케이션 개발',
-                  '프로세스 종료 시 데이터가 자동 삭제됩니다',
-                ],
+              const Center(
+                child: QuizpageAnswerlist(
+                  answerList: [
+                    '메모리 관리',
+                    'TLB(Translation)',
+                    '애플리케이션 개발',
+                    '프로세스 종료 시 데이터가 자동 삭제됩니다',
+                  ],
+                ),
               ),
-            ),
-            const Center(
-              child: QuizpageCardwidget(
-                quizCategory: '소프트웨어공학',
-                quizExplanation: '운영체제가 제공하는 기능에 해당하지 않는 것은 무엇인가요!',
-              ),
-            )
-          ],
+              const Center(
+                child: QuizpageCardwidget(
+                  quizCategory: '소프트웨어공학',
+                  quizExplanation: '운영체제가 제공하는 기능에 해당하지 않는 것은 무엇인가요!',
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -232,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  provider:
+    dependency: "direct dev"
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   shared_preferences:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## 이슈 번호
closed #27

## PR Type(Choose one)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## Changed Branch
hotfix#27-> dev

## Changes
- 퀴즈 페이지, 정답 페이지에서 뒤로 가기 버튼 작동을 막음
- 기존 UI의 home으로 돌아가기 버튼은 동일하게 작동

## Screenshot
생략

## Note
