### PR TITLE
update: 덱 구성 관련 페이지 API 연동

### DIFF
--- a/lib/features/deck/carddetailspage.dart
+++ b/lib/features/deck/carddetailspage.dart
@@ -107,7 +107,7 @@ class _CardDetailsPageState extends State<CardDetailsPage> {
             const SizedBox(height: 8),
 
             // 레이블 (눌러서 답 보기)
-            Text("눌러서 답 보기" ,
+            Text(bottomLabelText ,
               style: TextStyle(
                 fontSize: 24,
                 color: AppColors.mainDeepOrange.withOpacity(0.3),

--- a/lib/features/deck/carddetailspage.dart
+++ b/lib/features/deck/carddetailspage.dart
@@ -35,6 +35,7 @@ class _CardDetailsPageState extends State<CardDetailsPage> {
   // 카드 위젯 관련
   final GlobalKey<FlipCardState> _cardKey = GlobalKey<FlipCardState>();
   final _cardScaleFactor = 2.0;
+  String bottomLabelText = "눌러서 답 보기";
 
   @override
   void initState() {
@@ -82,6 +83,11 @@ class _CardDetailsPageState extends State<CardDetailsPage> {
               width: 300,
               height: 500,
               child: FlipCard(
+                onFlipDone: (isFront) {
+                  setState(() {
+                    bottomLabelText = isFront ? "눌러서 답 보기" : "눌러서 문제 보기";
+                  });
+                },
                 key: _cardKey,
                 direction: FlipDirection.HORIZONTAL,
                 side: CardSide.FRONT,
@@ -101,7 +107,7 @@ class _CardDetailsPageState extends State<CardDetailsPage> {
             const SizedBox(height: 8),
 
             // 레이블 (눌러서 답 보기)
-            Text("눌러서 답 보기",
+            Text("눌러서 답 보기" ,
               style: TextStyle(
                 fontSize: 24,
                 color: AppColors.mainDeepOrange.withOpacity(0.3),

--- a/lib/features/deck/cardlistpage.dart
+++ b/lib/features/deck/cardlistpage.dart
@@ -2,12 +2,12 @@ import 'package:cs_onecup/core/constants/colors.dart';
 import 'package:cs_onecup/core/widgets/cards/quizcardwidget.dart';
 import 'package:cs_onecup/data/models/quizcard.dart';
 import 'package:cs_onecup/data/models/quiztype.dart';
-// import 'package:cs_onecup/data/services/api_service.dart';
+import 'package:cs_onecup/data/services/api_service.dart';
 import 'package:cs_onecup/features/deck/widgets/simplequizcard.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// 카드 나열 페이지
+/// 카드 목록 페이지
 class CardListPage extends StatefulWidget {
 
   const CardListPage({super.key});
@@ -17,33 +17,22 @@ class CardListPage extends StatefulWidget {
 }
 
 class _CardListPageState extends State<CardListPage> {
-  // late ApiService apiService;
+  late ApiService apiService;
   late SharedPreferences pref;
-  final List<QuizCard> _dummyCards = List.generate(10, (index) => QuizCard.allArgsConstructor(
-      index,
-      QuizType.choice,
-      '제목 $index',
-      'DUMMY_CATEGORY',
-      '퀴즈 $index',
-      [], // choice
-      1,
-      // 설명
-      '012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
-    )
-  );
-  
   late List<QuizCard> _myCards;
+  bool _isLoading = true;
 
-  String truncate(String s, int limit) {
+  /// 카드 설명 길면 잘라냄
+  String _truncateExplanation(String s, int limit) {
     return '${s.substring(0, limit-3)}...';
   }
 
+  // TODO
   void onQuizCardTap(int index) {
     print("card touch $index");
   }
 
   /// pref 및 apiService 초기화
-  /*
   Future<void> _initialize() async {
     pref = await SharedPreferences.getInstance();
     String? jwt = await pref.getString('authToken');
@@ -51,25 +40,47 @@ class _CardListPageState extends State<CardListPage> {
   }
   
   /// Card 가져오기
-  Future<void> _fetchData() async {
+  Future<void> _fetchCards() async {
     _myCards = await apiService.get(
         'api/cards/user',
         fromJson: (jsonList) => jsonList
                                 .map((json) => QuizCard.fromJson(json))
                                 .toList());
-    _myCards.forEach((c) {
+    for (var c in _myCards) {
       print(c); // test
+    }
+
+    setState(() {
+      _isLoading = false;
     });
+  }
+  
+  /// dummy data 집어넣음 TODO 나중에 지우기
+  Future<void> _putDummyData() async {
+    _myCards = List.generate(10, (index) => QuizCard.allArgsConstructor(
+        index,
+        QuizType.choice,
+        '제목 $index',
+        'DUMMY_CATEGORY',
+        '퀴즈 $index',
+        [], // choice
+        1,
+        // 설명
+        '012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
+    )
+    );
   }
   
   @override
   void initState() {
     super.initState();
     _initialize().then((_) {
-      _fetchData();
+      _fetchCards().then((_) {
+        _putDummyData(); // TODO 나중에 지우기
+      });
     });
     // API 호출하는 다른 함수
-  }*/
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -143,12 +154,24 @@ class _CardListPageState extends State<CardListPage> {
             ),
             const SizedBox(height: 16),
 
+
+            _isLoading
+            // API Fetch 전엔 로딩 화면 출력
+            ? const CircularProgressIndicator()
             // 카드 Grid View 나열
-            Expanded(
+            : Expanded(
               child: Padding(
                 padding: const EdgeInsets.all(8.0),
-                child: GridView.builder(
-                  itemCount: _dummyCards.length, // 카드 개수
+                child: 
+                _myCards.isEmpty
+                // 카드 없으면 텍스트 출력
+                ? const Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Center(child: Text("카드가 없습니다!", style: TextStyle(color: Colors.black, fontSize: 36),)),
+                )
+                // 카드 있으면 GridView로 출력
+                : GridView.builder(
+                  itemCount: _myCards.length, // 카드 개수
                   // itemCount: _myCards.length,
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2, // 가로 2개
@@ -162,8 +185,8 @@ class _CardListPageState extends State<CardListPage> {
                       child: SimpleQuizCard(
                         // quizCategory: _myCards[index].category,
                         // quizExplanation: _myCards[index].explanation,
-                        quizCategory: _dummyCards[index].category,
-                        quizExplanation: truncate(_dummyCards[index].explanation, 60),
+                        quizCategory: _myCards[index].category,
+                        quizExplanation: _truncateExplanation(_myCards[index].explanation, 60),
                       ),
                     );
                   },

--- a/lib/features/deck/cardlistpage.dart
+++ b/lib/features/deck/cardlistpage.dart
@@ -35,7 +35,7 @@ class _CardListPageState extends State<CardListPage> {
             cardTitle: _myCards[index].title,
             quizCategory: _myCards[index].category,
             quizExplanation: _myCards[index].question,
-            quizAnswer: _myCards[index].choice[_myCards[index].answer], // TODO index 맞는지 확인
+            quizAnswer: _myCards[index].choice[_myCards[index].answer - 1],
             answerExplanation: _myCards[index].explanation))
     );
   }

--- a/lib/features/deck/cardlistpage.dart
+++ b/lib/features/deck/cardlistpage.dart
@@ -3,6 +3,7 @@ import 'package:cs_onecup/core/widgets/cards/quizcardwidget.dart';
 import 'package:cs_onecup/data/models/quizcard.dart';
 import 'package:cs_onecup/data/models/quiztype.dart';
 import 'package:cs_onecup/data/services/api_service.dart';
+import 'package:cs_onecup/features/deck/carddetailspage.dart';
 import 'package:cs_onecup/features/deck/widgets/simplequizcard.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -27,9 +28,16 @@ class _CardListPageState extends State<CardListPage> {
     return '${s.substring(0, limit-3)}...';
   }
 
-  // TODO
   void onQuizCardTap(int index) {
     print("card touch $index");
+    Navigator.push(context, MaterialPageRoute(
+        builder: (context) => CardDetailsPage(
+            cardTitle: _myCards[index].title,
+            quizCategory: _myCards[index].category,
+            quizExplanation: _myCards[index].question,
+            quizAnswer: _myCards[index].choice[_myCards[index].answer], // TODO index 맞는지 확인
+            answerExplanation: _myCards[index].explanation))
+    );
   }
 
   /// pref 및 apiService 초기화
@@ -41,16 +49,14 @@ class _CardListPageState extends State<CardListPage> {
   
   /// Card 가져오기
   Future<void> _fetchCards() async {
-    _myCards = await apiService.get(
+    final fetchedCards = await apiService.get(
         'api/cards/user',
         fromJson: (jsonList) => jsonList
                                 .map((json) => QuizCard.fromJson(json))
                                 .toList());
-    for (var c in _myCards) {
-      print(c); // test
-    }
-
+    for (var c in _myCards) print(c); // test
     setState(() {
+      _myCards = fetchedCards;
       _isLoading = false;
     });
   }
@@ -71,15 +77,16 @@ class _CardListPageState extends State<CardListPage> {
     );
   }
   
+  Future<void> _fetchApiData() async {
+    await _initialize();
+    await _fetchCards();
+    await _putDummyData(); // TODO 나중에 지우기
+  }
+  
   @override
   void initState() {
     super.initState();
-    _initialize().then((_) {
-      _fetchCards().then((_) {
-        _putDummyData(); // TODO 나중에 지우기
-      });
-    });
-    // API 호출하는 다른 함수
+    _fetchApiData();
   }
 
   @override

--- a/lib/features/deck/deckdetailspage.dart
+++ b/lib/features/deck/deckdetailspage.dart
@@ -1,28 +1,70 @@
+import "package:cs_onecup/data/services/api_service.dart";
+import "package:cs_onecup/features/deck/carddetailspage.dart";
 import 'package:flutter/material.dart';
 import "package:cs_onecup/core/constants/colors.dart";
 import "package:cs_onecup/features/deck/widgets/simplecardtile.dart";
 import "package:cs_onecup/data/models/quizcard.dart";
+import "package:shared_preferences/shared_preferences.dart";
 
 
 class DeckDetailsPage extends StatefulWidget {
-  const DeckDetailsPage({super.key});
+  final int deckId;
+  const DeckDetailsPage({super.key, required this.deckId});
   @override
   State<DeckDetailsPage> createState() => _DeckDetailsPageState();
 }
 
 class _DeckDetailsPageState extends State<DeckDetailsPage> {
 
-  // TODO API 연결
-  List<QuizCard> cards = [];
+  late SharedPreferences pref;
+  late ApiService apiService;
+  late List<QuizCard> _cards;
+  late String? _deckTitle;
   
   void editDeck() {
     // TODO
   }
   
   void shareDeck() {
-    // 확인 창 띄우고 공유
+    // TODO 확인 창 띄우고 공유
   }
 
+  /// pref 및 apiService 초기화
+  Future<void> _initialize() async {
+    pref = await SharedPreferences.getInstance();
+    String? jwt = await pref.getString('authToken');
+    apiService = ApiService(defaultHeader: {'Authorization': jwt ?? ''});
+  }
+
+  /// 덱 카드 가져오기
+  Future<void> _fetchCards() async {
+    final response = await apiService.get(
+        'api/decks/${widget.deckId}/cards',
+        fromJson: (json) => (json)
+    );
+    final cards = (response['cards'] as List<Map<String, dynamic>>)
+            .map((cardJson) => QuizCard.fromJson(cardJson))
+            .toList();
+
+    print("DeckDetailsPage: fetched deck named $_deckTitle");
+    for(var card in cards) print(card); // test
+
+    setState(() {
+      _deckTitle = response['deck_info']['name'];
+      _cards = cards;
+    });
+  }
+
+  Future<void> _fetchApiData() async {
+    await _initialize();
+    await _fetchCards();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchApiData();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -70,29 +112,52 @@ class _DeckDetailsPageState extends State<DeckDetailsPage> {
             child: Column(
               children: [
                 Text(
-                  "나의 덱 이름",
-                  style: TextStyle(
+                  _deckTitle ?? '나의 덱',
+                  style: const TextStyle(
                     fontSize: 35,
                     fontWeight: FontWeight.normal,
                     color: AppColors.mainDeepOrange,
                   ),
                 ),
-                SizedBox(height: 4),
+                const SizedBox(height: 4),
                 Text(
-                  "18 cards",
+                  "${_cards.length} cards",
                   style: TextStyle(
                       fontSize: 16,
                       color: AppColors.mainDeepOrange.withOpacity(0.5)),
                 ),
-                SizedBox(height: 45,)
+                const SizedBox(height: 45,)
               ],
             ),
           ),
-          // 카드 리스트
-          Expanded(
+
+          _cards.isEmpty
+          // 카드 빈 경우 텍스트 출력
+          ? const Padding(
+            padding: EdgeInsets.all(16),
+            child: Text("덱이 비었습니다!", style: TextStyle(fontSize: 36,),),
+          )
+          // 카드 리스트 출력
+          : Expanded(
               child: ListView.builder(
-                itemCount: 15,
-                itemBuilder: (context, index) => SimpleCardTile(index: index)
+                itemCount: _cards.length,
+                itemBuilder: (context, index) => SimpleCardTile(
+                  index: index,
+                  title: _cards[index].title,
+                  category: _cards[index].category,
+                  card: _cards[index],
+                  onTap: (quizCard) {
+                    print("tapped card $index (name: ${quizCard.title}");
+                    Navigator.push(context, MaterialPageRoute(
+                            builder: (context) => CardDetailsPage(
+                                cardTitle: quizCard.title,
+                                quizCategory: quizCard.category,
+                                quizExplanation: quizCard.question,
+                                quizAnswer: quizCard.choice[quizCard.answer], // TODO indexing 맞는지 확인
+                                answerExplanation: quizCard.explanation))
+                    );
+                  },
+                )
               )
           )
         ],

--- a/lib/features/deck/deckdetailspage.dart
+++ b/lib/features/deck/deckdetailspage.dart
@@ -153,7 +153,7 @@ class _DeckDetailsPageState extends State<DeckDetailsPage> {
                                 cardTitle: quizCard.title,
                                 quizCategory: quizCard.category,
                                 quizExplanation: quizCard.question,
-                                quizAnswer: quizCard.choice[quizCard.answer], // TODO indexing 맞는지 확인
+                                quizAnswer: quizCard.choice[quizCard.answer - 1],
                                 answerExplanation: quizCard.explanation))
                     );
                   },

--- a/lib/features/deck/deckdetailspage.dart
+++ b/lib/features/deck/deckdetailspage.dart
@@ -32,7 +32,7 @@ class _DeckDetailsPageState extends State<DeckDetailsPage> {
   /// pref 및 apiService 초기화
   Future<void> _initialize() async {
     pref = await SharedPreferences.getInstance();
-    String? jwt = await pref.getString('authToken');
+    String? jwt = pref.getString('authToken');
     apiService = ApiService(defaultHeader: {'Authorization': jwt ?? ''});
   }
 

--- a/lib/features/deck/widgets/simplecardtile.dart
+++ b/lib/features/deck/widgets/simplecardtile.dart
@@ -1,4 +1,5 @@
 import 'package:cs_onecup/core/utils/icon_fetcher.dart';
+import 'package:cs_onecup/data/models/quizcard.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/constants/colors.dart';
@@ -9,67 +10,65 @@ class SimpleCardTile extends StatelessWidget {
   final int index;
   final String title;
   final String category;
-  // final Card? card;
+  final void Function(QuizCard)? onTap; // 아마 카드 상세 페이지 띄우게 하기
+  final QuizCard card;
 
   const SimpleCardTile({
     super.key,
     required this.index,
     String? title,
-    String? category
+    String? category,
+    required this.card,
+    this.onTap
   })
   : this.title = title ?? '카드 제목',
     this.category = category ?? 'None';
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
-      child: Container(
-        // 바깥 컨테이너 (흰색)
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: Colors.black, width: 2.5),
-        ),
-        child: Padding(
-          // 내부 컨테이너 (베이지색)
-          padding: const EdgeInsets.all(4.0), // 흰 테두리 두꼐
-          child: Container(
-            decoration: BoxDecoration(
-              color: AppColors.cardBeige,
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: ListTile(
-              // 아이콘
-              leading: IconFetcher.fetchImage(category, width: 30, height: 30),
-              // leading: Container(
-              //   child:
-              //   // padding: const EdgeInsets.all(8),
-              //   // decoration: BoxDecoration(
-              //   //   borderRadius: BorderRadius.circular(8),
-              //   // ),
-              //   // child: const Icon(Icons.format_list_bulleted, color: Colors.brown),
-              // ),
-              // 제목
-              title: Center(
-                child: Text(
-                  title,
-                  style: const TextStyle(
-                    fontSize: 25,
-                    color: AppColors.mainDeepOrange,
-                    fontWeight: FontWeight.normal,
-                    overflow: TextOverflow.ellipsis
+    return GestureDetector(
+      onTap: () => onTap != null ? onTap!(card) : null,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+        child: Container(
+          // 바깥 컨테이너 (흰색)
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: Colors.black, width: 2.5),
+          ),
+          child: Padding(
+            // 내부 컨테이너 (베이지색)
+            padding: const EdgeInsets.all(4.0), // 흰 테두리 두꼐
+            child: Container(
+              decoration: BoxDecoration(
+                color: AppColors.cardBeige,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: ListTile(
+                // 아이콘
+                leading: IconFetcher.fetchImage(category, width: 30, height: 30),
+                // 제목
+                title: Center(
+                  child: Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 25,
+                      color: AppColors.mainDeepOrange,
+                      fontWeight: FontWeight.normal,
+                      overflow: TextOverflow.ellipsis
+                    ),
                   ),
                 ),
+                onTap: () {
+                  // 카드 클릭 이벤트
+                },
               ),
-              onTap: () {
-                // 카드 클릭 이벤트
-              },
             ),
           ),
         ),
-      ),
 
+      ),
     );
   }
 }


### PR DESCRIPTION
😩
## 이슈 번호
> closes #44 

## PR Type(Choose one)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## Changed Branch
> update#44 -> dev

## Changes
담당 페이지 API 연동
- 카드 목록 페이지 (`CardListPage`)
- 덱 상세 정보 페이지 (`DeckDetailsPage`)
- 덱 생성 페이지 (`DeckCreatePage`)

소소한 UI 변경점
- 카드 상세 페이지 아래 레이블 수정
  - 카드 flip 시 `눌러서 답 보기` -> `눌러서 문제 보기`로 변경됨
- `SimpleCardTile` 누를 시 카드 상세 페이지로 라우팅


## Screenshot
❌ 


## Note
### 테스트 필요
API 전송할 때 jwt가 필요해서 아직 테스트는 못함.
라우팅 연결하고 해야할 듯

### 더미 데이터 채워 놓은 상태
![image](https://github.com/user-attachments/assets/06edeaef-d7d8-4ee1-8e50-d0fb83a1f909)
이런 식으로 더미 데이터 채워놨는데, 배포 시 삭제해야 함
- TODO 주석으로 마킹해둠
